### PR TITLE
use conda-build 3.24 and drop libsolv constraint

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   script: {{ PYTHON }} -m pip install . --no-deps -vv
-  number: 3
+  number: 4
   noarch: python
   entry_points:
     - conda-mambabuild = boa.cli.mambabuild:main
@@ -23,7 +23,7 @@ requirements:
     - pip
   run:
     - python >=3.6
-    - conda-build >=3.20,<3.24
+    - conda-build >=3.24,<3.25
     - mamba >=1.0,<1.5
     - ruamel.yaml
     - jinja2
@@ -35,9 +35,6 @@ requirements:
     - watchgod
     # for python 3.6 compatibility
     - dataclasses
-  # Workaround for https://github.com/conda/conda-build/issues/4750
-  run_constrained:
-    - libsolv <0.7.23
 
 test:
   imports:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
