### PR TITLE
Extend mamba pin

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
   run:
     - python >=3.6
     - conda-build >=3.24,<3.26
-    - mamba >=1.0,<=1.4.2
+    - mamba >=1.4.5,<=1.4.9
     - ruamel.yaml
     - jinja2
     - rich


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

There is an issue in conda, only fixed in `23.7.0` which effectively prevents us from using recent package versions in our environments (earlier versions of conda have an incompatibility with recent versions of `requests`, see [here](https://github.com/conda/conda/pull/12683)). Unfortunately the current version of `boa` pins `mamba <= 1.4.2`, and then that version of mamba requires `conda <= 23.4`.

Examples:

Cannot solve
```
FROM mambaorg/micromamba:jammy as build-stage

RUN micromamba create --dry-run --name boa --channel conda-forge \
    "python 3.10.*" \
    "boa >=0.15.1" \
    "conda >=23.7.1"
```
or
```
FROM mambaorg/micromamba:jammy as build-stage

RUN micromamba create --dry-run --name boa --channel conda-forge \
    "python 3.10.*" \
    "mamba 1.4.2" \
    "conda >=23.7.1"
```
But the following solves:
```
FROM mambaorg/micromamba:jammy as build-stage

RUN micromamba create --dry-run --name boa --channel conda-forge \
    "python 3.10.*" \
    "mamba 1.4.5" \
    "conda >=23.7.1"
```