### PR TITLE
Add missing dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   script: {{ PYTHON }} -m pip install . --no-deps -vv
-  number: 0
+  number: 1
   noarch: python
   entry_points:
     - conda-mambabuild = boa.cli.mambabuild:main
@@ -34,6 +34,7 @@ requirements:
     - joblib
     - watchgod
     - beautifulsoup4
+    - boltons
 
 test:
   imports:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Fixes #81.

<!--
Please add any other relevant info below:
-->

* `boltons` was added as a new dependency in https://github.com/mamba-org/boa/commit/776609b38ccf5e8fd1cd39ae38d011136cc367fc but not included when updating to 0.17.0 here.
* We noticed this because we use `boa` to build our installers in Spyder and the workflow we used for that started to fail due to `boltons` not being present.